### PR TITLE
Add timeout to `requests` calls

### DIFF
--- a/data_scripts/helpers/gis.py
+++ b/data_scripts/helpers/gis.py
@@ -33,7 +33,7 @@ def get_wic_sites() -> list:
     }
 
     response = requests.post(WIC_SERVICE + resource,
-                             json=payload, headers=headers)
+                             json=payload, headers=headers, timeout=60)
 
     if response.status_code == 200:
         output_json = response.json()
@@ -60,7 +60,7 @@ def get_snap_sites() -> list:
         'f': 'json'
     }
     results = []
-    response = requests.get(GIS_1_SERVICE + resource, params=params)
+    response = requests.get(GIS_1_SERVICE + resource, params=params, timeout=60)
     if response.status_code == 200:
         output = response.json()
         if 'features' in output and output['features']:
@@ -97,7 +97,7 @@ def get_fmnp_markets() -> list:
 
     results = []
     resource = '/n3KaqXoFYDuIhfyz/ArcGIS/rest/services/FMNPMarkets/FeatureServer/0/query'
-    response = requests.get(GIS_5_SERVICE + resource, params=params)
+    response = requests.get(GIS_5_SERVICE + resource, params=params, timeout=60)
 
     if response.status_code == 200:
         output = response.json()
@@ -134,7 +134,7 @@ def get_gpcfb_sites() -> list:
 
     resource = '/vdNDkVykv9vEWFX4/arcgis/rest/services/COVID19_Food_Access_(PUBLIC)/FeatureServer/0/query'
 
-    response = requests.get(GIS_1_SERVICE + resource, params=params)
+    response = requests.get(GIS_1_SERVICE + resource, params=params, timeout=60)
 
     if response.status_code == 200:
         output = response.json()
@@ -167,7 +167,7 @@ def get_schedule_entry(market_id: str) -> list:
     }
 
     resource = '/n3KaqXoFYDuIhfyz/ArcGIS/rest/services/FMNPMarkets/FeatureServer/1/query'
-    response = requests.get(GIS_5_SERVICE + resource, params=params)
+    response = requests.get(GIS_5_SERVICE + resource, params=params, timeout=60)
 
     schedules = []
     if response.status_code == 200:
@@ -217,7 +217,7 @@ def get_summer_meal_sites() -> list:
         'f': 'geojson'
     }
     resource = '/vdNDkVykv9vEWFX4/arcgis/rest/services/Child_Nutrition/FeatureServer/0/query'
-    response = requests.get(GIS_1_SERVICE + resource, params=params)
+    response = requests.get(GIS_1_SERVICE + resource, params=params, timeout=60)
 
     if response.status_code == 200:
         output = response.json()
@@ -250,7 +250,7 @@ def get_google_sheet_csv(sheet_id: str, gid: str) -> list:
         'gid': gid
     }
 
-    response = requests.get(GOOGLE_SHEETS, params=params)
+    response = requests.get(GOOGLE_SHEETS, params=params, timeout=60)
 
     if response.status_code == 200:
         output = response.content.decode()

--- a/data_scripts/helpers/mapbox.py
+++ b/data_scripts/helpers/mapbox.py
@@ -24,7 +24,7 @@ def get_coordinates(key: str, address: str) -> dict | None:
         url = SERVICE_ADDRESS.replace('$search', address)
         params = {'access_token': key, 'limit': 1, 'types': 'address'}
 
-        response = requests.get(url, params=params)
+        response = requests.get(url, params=params, timeout=60)
 
         if response.status_code == 200:
             body = response.json()


### PR DESCRIPTION
Many developers will be surprised to learn that `requests` library calls do not include timeouts by default. This means that an attempted request could hang indefinitely if no connection is established or if no data is received from the server. 

The [requests documentation](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts) suggests that most calls should explicitly include a `timeout` parameter. This codemod adds a default timeout value in order to set an upper bound on connection times and ensure that requests connect or fail in a timely manner. This value also ensures the connection will timeout if the server does not respond with data within a reasonable amount of time. 

While timeout values will be application dependent, we believe that this codemod adds a reasonable default that serves as an appropriate ceiling for most situations. 

Our changes look like the following:
```diff
 import requests
 
- requests.get("http://example.com")
+ requests.get("http://example.com", timeout=60)
```

<details>
  <summary>More reading</summary>

  * [https://docs.python-requests.org/en/master/user/quickstart/#timeouts](https://docs.python-requests.org/en/master/user/quickstart/#timeouts)
</details>


Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/add-requests-timeouts](https://docs.pixee.ai/codemods/python/pixee_python_add-requests-timeouts)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Ffood-access-data-transformation%7C351768bbea2e21ad8887c430ff49c8a8ff55566d)

<!--{"type":"DRIP","codemod":"pixee:python/add-requests-timeouts"}-->